### PR TITLE
Ignore iPad.

### DIFF
--- a/FTLinearActivityIndicator/Classes/UIApplication+LinearNetworkActivityIndicator.swift
+++ b/FTLinearActivityIndicator/Classes/UIApplication+LinearNetworkActivityIndicator.swift
@@ -13,7 +13,9 @@ extension UIApplication {
 		if #available(iOS 11.0, *) {
 			// detect iPhone X
 			if let window = shared.windows.first, window.safeAreaInsets.bottom > 0.0 {
-				configureLinearNetworkActivityIndicator()
+				if UIDevice.current.userInterfaceIdiom != .pad {
+					configureLinearNetworkActivityIndicator()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Ignore iPad in the `configureLinearNetworkActivityIndicatorIfNeeded()` method, as the new iPad Pro also has `window.safeAreaInsets.bottom > 0.0`. Otherwise it will add the linear network activity indicator behind the elements of the status bar and also, the new iPad does display the normal activity indicator.